### PR TITLE
feat: 닉네임 api 연동

### DIFF
--- a/server/src/App.tsx
+++ b/server/src/App.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import BannerResult from './pages/BannerResult';
 import ThemeResult from './pages/ThemeResultPage';
-import BackgroundTheme from './pages/ThemeSelcetPage';
+import Nickname from './pages/NicknamePage';
 
 const App: React.FC = () => {
   return (
     <Router>
       <Routes>
-        <Route path='/' element={<ThemeResult />}/>
+        <Route path='/' element={<Nickname />}/>
         <Route path="/banner" element={<div>Banner Page</div>} />
         <Route path="/background" element={<div>Background Page</div>} />
         <Route path="/about" element={<div>About Page</div>} />

--- a/server/src/components/MainButton.tsx
+++ b/server/src/components/MainButton.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-{/*이 컴포넌트는 높이 너비를 최대로 해놨습니다. 
-  따라서 페이지에서 사용하실때 태그에 알맞은 사이즈를 지정하시고 이 컴포넌트를 사용하시면 됩니다. */}
-
-
 interface ButtonProps {
   value: string;
-
+  onClick?: () => void; // 'onClick'으로 변경
 }
 
-const MainButton:React.FC<ButtonProps> = (props) =>  {
+const MainButton: React.FC<ButtonProps> = (props) => {
   return (
-    <button className="flex-shrink-0 flex text-center w-full h-full justify-center items-center rounded-[7px] bg-green-Normal hover:bg-green-Normal :hover hover:font-PR_BO active:font-PR_BO  active:bg-green-Normal :active text-max-xl font-PR_M text-black hover:text-black active:text-black" >
-    {props.value}</button>
+    <button
+      className="flex-shrink-0 flex text-center w-full h-full justify-center items-center rounded-[7px] bg-green-Normal hover:bg-green-Normal :hover hover:font-PR_BO active:font-PR_BO active:bg-green-Normal :active text-max-xl font-PR_M text-black hover:text-black active:text-black"
+      onClick={props.onClick} // onClick 속성을 추가
+    >
+      {props.value}
+    </button>
   );
 };
 

--- a/server/src/pages/NicknamePage.tsx
+++ b/server/src/pages/NicknamePage.tsx
@@ -1,17 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/NavBar';
 import MainButton from '../components/MainButton';
+import axios from 'axios';
 
-interface NicknameProps {
-  nickname: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
+const Nickname: React.FC = () => {
+  const [nickname, setNickname] = useState<string>('');
+  const [nicknameSuccess, setNicknameSuccess] = useState<string>('');
+  const [nicknameError, setNicknameError] = useState<string>('');
 
-const Nickname: React.FC<NicknameProps> = ({ nickname, onChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    setNicknameError(''); // 입력할 때마다 에러 메시지를 초기화
+    setNicknameSuccess(''); // 입력할 때마다 성공 메시지를 초기화
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const response = await axios.post('http://localhost:8000/api/v1/nicknames/', { nickname });
+      console.log('Nickname registered successfully:', response.data);
+      setNicknameSuccess('닉네임이 성공적으로 생성되었습니다.');
+    } catch (error: any) {
+      if (error.response && error.response.status === 400) {
+        setNicknameError('중복된 닉네임입니다. 다른 닉네임을 입력해주세요.');
+      } else {
+        console.error('Error registering nickname:', error);
+        setNicknameError('닉네임 등록 중 오류가 발생했습니다. 다시 시도해주세요.');
+      }
+    }
+  };
+
   return (
     <div className="relative w-full h-full min-h-screen bg-[#111] overflow-hidden">
       <NavBar />
-      <div className="flex flex-col items-center justify-start min-h-screen mt-20"> {/* Adjusted here */}
+      <div className="flex flex-col items-center justify-start min-h-screen mt-20">
         <div className="w-full flex flex-col items-center justify-center py-[30px] px-[5%] bg-[#111] overflow-hidden">
         </div>
         <div className="w-[90%] max-w-[600px] flex flex-wrap items-center justify-center py-[5%] px-[5%] overflow-hidden">
@@ -25,13 +46,19 @@ const Nickname: React.FC<NicknameProps> = ({ nickname, onChange }) => {
                 <input
                   type="text"
                   value={nickname}
-                  onChange={onChange}
+                  onChange={handleChange}
                   className="absolute left-[10px] top-[10px] w-[calc(100%-20px)] h-[calc(100%-20px)] text-[1rem] leading-[160%] font-['Pretendard'] font-medium text-white bg-black outline-none"
                 />
               </div>
             </div>
+            {nicknameError && (
+              <div className="mt-2 text-sm text-red">{nicknameError}</div>
+            )}
+            {nicknameSuccess && (
+              <div className="mt-2 text-sm text-green-Normal">{nicknameSuccess}</div>
+            )}
           </div>
-            <MainButton value='확인'/>
+          <MainButton value='확인' onClick={handleSubmit} /> {/* onClick 속성 추가 */}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> feat/#65

## 📝작업 내용

> 닉네임 페이지 -> 닉네임 api 연동
-> 닉네임 성공 로그, 닉네임 중복 로그 표시되도록 설정

### 스크린샷 
![image](https://github.com/user-attachments/assets/6ac4e5d8-db21-4ffb-ac34-b8252e4e806f)


## 💬리뷰 요구사항(선택)
