### PR TITLE
feat: MainChoose 페이지 Api 구현

### DIFF
--- a/server/src/pages/MainChoose.tsx
+++ b/server/src/pages/MainChoose.tsx
@@ -1,17 +1,33 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import MoveChoose from '../components/MoveChoose';
 import MoveChoose2 from '../components/MoveChoose2';
 import MainButton from '../components/MainButton';
+import axios from 'axios';
 
-interface NameProps {
-  name: string;
-}
-
-const MainChoose: React.FC<NameProps> = (props) => {
+const MainChoose: React.FC = () => {
   const [activeButton, setActiveButton] = useState<string | null>(null);
   const [Rayout, setRayout] = useState<string | null>(null);
+  const [data, setData] = useState<string>('');
   const navigate = useNavigate();
+  const location = useLocation();
+  const { userid } = location.state || {};
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        if (userid) {
+          const response = await axios.get(`http://localhost:8000/api/v1/nicknames/${userid}`);
+          setData(response.data.data.nickname); // 응답 데이터에서 닉네임을 추출하여 상태로 설정
+          if (response.status !== 200) throw new Error('Error fetching data');
+        }
+      } catch (error) {
+        console.error('Error fetching nickname:', error);
+      }
+    };
+
+    fetchData();
+  }, [userid]);
 
   const handleButtonClick = (buttonType: string) => {
     setActiveButton(buttonType);
@@ -44,17 +60,18 @@ const MainChoose: React.FC<NameProps> = (props) => {
                   안녕하세요!
                 </p>
                 <p className="my-12 text-4xl font-PR_BO text-left text-white">
-                  {props.name}님
+                  {data}님
                 </p>
               </div>
             )}
           </div>
           {activeButton ? (
-          <div  onClick={activeButton ? handleStartClick : undefined}
-                className={activeButton ? 'bg-green-Normal "w-full h-14 rounded-[10px] overflow-hidden place-content-center' : 'bg-[#b8b8b8] "w-full h-14 rounded-[10px] overflow-hidden place-content-center'}
+            <div
+              onClick={activeButton ? handleStartClick : undefined}
+              className={activeButton ? 'bg-green-Normal w-full h-14 rounded-[10px] overflow-hidden place-content-center' : 'bg-[#b8b8b8] w-full h-14 rounded-[10px] overflow-hidden place-content-center'}
             >
-            <MainButton value='시작하기' />
-          </div>
+              <MainButton value='시작하기' />
+            </div>
           ) : (
             <div className="w-full h-14 rounded-[10px] bg-[#b8b8b8] overflow-hidden place-content-center">
               <button className="text-xl font-PR_BO text-center text-white w-full h-full">

--- a/server/src/pages/Nickname.tsx
+++ b/server/src/pages/Nickname.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import MainButton from '../components/MainButton';
 
@@ -8,6 +8,7 @@ const Nickname: React.FC = () => {
   const [nickname, setNickname] = useState<string>('');
   const [nicknameSuccess, setNicknameSuccess] = useState<string>('');
   const [nicknameError, setNicknameError] = useState<string>('');
+  const navigate = useNavigate();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNickname(e.target.value);
@@ -20,6 +21,8 @@ const Nickname: React.FC = () => {
       const response = await axios.post('http://localhost:8000/api/v1/nicknames/', { nickname });
       console.log('Nickname registered successfully:', response.data);
       setNicknameSuccess('닉네임이 성공적으로 생성되었습니다.');
+      const userId = response.data.data.id;
+      navigate('/mainchoose', { state: { userid: userId } }); // 닉네임 생성이 성공하면 페이지 이동
     } catch (error: any) {
       if (error.response && error.response.status === 400) {
         setNicknameError('중복된 닉네임입니다. 다른 닉네임을 입력해주세요.');
@@ -27,13 +30,14 @@ const Nickname: React.FC = () => {
         console.error('Error registering nickname:', error);
         setNicknameError('닉네임 등록 중 오류가 발생했습니다. 다시 시도해주세요.');
       }
+      setNicknameSuccess('');
     }
   };
 
   return (
     <div className='flex flex-col h-screen'>
       <div className='flex-shrink-0'>
-      <NavBar />
+        <NavBar />
       </div>
       <div className="flex flex-1 justify-center items-center bg-black">
         <div className='flex flex-col justify-center items-center w-3/12 gap-3'>
@@ -48,19 +52,17 @@ const Nickname: React.FC = () => {
             className="rounded-lg border border-green-Light text-green-Light font-PR_L w-full h-[44px] bg-black px-3"
           />
           {nicknameError && (
-              <div className="mt-2 text-sm text-red">{nicknameError}</div>
-            )}
-            {nicknameSuccess && (
-              <div className="mt-2 text-sm text-green-Normal">{nicknameSuccess}</div>
-            )}
-          <div className='w-full mt-4 h-[40px]'>
-            <Link to="/mainchoose">
-              <MainButton value='확인' onClick={handleSubmit}/>
-            </Link>
-            </div>
+            <div className="mt-2 text-sm text-red">{nicknameError}</div>
+          )}
+          {nicknameSuccess && (
+            <div className="mt-2 text-sm text-green-Normal">{nicknameSuccess}</div>
+          )}
+          <div className='w-full mt-4 h-[42px]'>
+            <MainButton value='확인' onClick={handleSubmit} />
           </div>
         </div>
       </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #67 

## 📝작업 내용

> MainChoose 페이지 Api 구현 및 Nickname 페이지 중복검사 수정

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1640f37b-7d6e-4a80-a825-02ef0bfcd63b)


## 💬리뷰 요구사항(선택)
